### PR TITLE
Make it easier to launch the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,11 @@ chart (Tuple width height) =
       .attr("fill", d => scale(d.group))
 ```
 
+# Quickstart to run an example
+
+Note that this is for a different example than the above, and assumes you already have `purescript` and `spago` installed.
+```
+npm i
+npm run example
+```
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "http-server": "^0.12.3"
+  },
+  "scripts": {
+    "bundle": "spago bundle-app -t dist/bundle.js",
+    "serve": "http-server dist -a localhost --port 1234 -o",
+    "example": "npm run bundle; npm run serve"
+  }
+}


### PR DESCRIPTION
I'd like to port these examples next:
https://github.com/afcondon/purescript-d3v4/tree/master/examples

Do you anticipate migration challenges with any of those examples? Do you recommend any to start with for a D3 beginner?

I also missed any context you shared about this library in the [most recent meetup](https://discourse.purescript.org/t/semimonthly-online-meetup-2020-10-12/1597/44), so I'm a bit unfamiliar with the current [MVP status](https://discourse.purescript.org/t/announcing-purescript-d3js-but-for-real-this-time/1707) and this library's overall strategy (beyond what's in the readme).

I'm planning on diving into D3 (for the first time) with my current PS project, so should be pretty motivated to help fill in any missing pieces with this library along the way.